### PR TITLE
feat: Add IndexedDB storage driver

### DIFF
--- a/packages/picosearch/src/constants.ts
+++ b/packages/picosearch/src/constants.ts
@@ -7,6 +7,9 @@ export const DEFAULT_ID_FIELD = 'id';
 
 export const DEFAULT_STORAGE_DRIVER_KEY = 'picosearch';
 
+export const DEFAULT_INDEXEDDB_DB_NAME = 'picosearch';
+export const DEFAULT_INDEXEDDB_STORE_NAME = 'data';
+
 export const UNSERIALIZABLE_OPTIONS = [
   'storageDriver',
   'tokenizer',

--- a/packages/picosearch/src/constants.ts
+++ b/packages/picosearch/src/constants.ts
@@ -5,6 +5,10 @@ import type { Analyzer, Tokenizer } from './types';
 
 export const DEFAULT_ID_FIELD = 'id';
 
+export const DEFAULT_STORAGE_DRIVER_KEY = 'picosearch';
+export const DEFAULT_INDEXEDDB_DB_NAME = 'picosearch';
+export const DEFAULT_INDEXEDDB_STORE_NAME = 'data';
+
 export const UNSERIALIZABLE_OPTIONS = [
   'storageDriver',
   'tokenizer',

--- a/packages/picosearch/src/constants.ts
+++ b/packages/picosearch/src/constants.ts
@@ -5,11 +5,6 @@ import type { Analyzer, Tokenizer } from './types';
 
 export const DEFAULT_ID_FIELD = 'id';
 
-export const DEFAULT_STORAGE_DRIVER_KEY = 'picosearch';
-
-export const DEFAULT_INDEXEDDB_DB_NAME = 'picosearch';
-export const DEFAULT_INDEXEDDB_STORE_NAME = 'data';
-
 export const UNSERIALIZABLE_OPTIONS = [
   'storageDriver',
   'tokenizer',

--- a/packages/picosearch/src/schemas.ts
+++ b/packages/picosearch/src/schemas.ts
@@ -23,26 +23,41 @@ const StorageDriverSchema = z.object({
 
 export type StorageDriver = z.input<typeof StorageDriverSchema>;
 
-const StorageDriverOptionsSchema = z.union([
-  z.literal('localstorage'),
-  z.literal('indexeddb'),
-  z.discriminatedUnion('type', [
-    z.object({
-      type: z.literal('localstorage'),
-      key: z.string(),
-    }),
-    z.object({
-      type: z.literal('indexeddb'),
-      key: z.string(),
-      dbName: z.string().optional(),
-      storeName: z.string().optional(),
-    }),
-    z.object({
-      type: z.literal('custom'),
-      driver: StorageDriverSchema,
-    }),
-  ]),
-]);
+const StorageDriverOptionsSchema = z
+  .union([
+    z.literal('localstorage'),
+    z.literal('indexeddb'),
+    z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('localstorage'),
+        key: z.string().default('picosearch'),
+      }),
+      z.object({
+        type: z.literal('indexeddb'),
+        key: z.string().default('picosearch'),
+        dbName: z.string().default('picosearch'),
+        storeName: z.string().default('data'),
+      }),
+      z.object({
+        type: z.literal('custom'),
+        driver: StorageDriverSchema,
+      }),
+    ]),
+  ])
+  .transform((val) => {
+    if (val === 'localstorage') {
+      return { type: 'localstorage' as const, key: 'picosearch' };
+    }
+    if (val === 'indexeddb') {
+      return {
+        type: 'indexeddb' as const,
+        key: 'picosearch',
+        dbName: 'picosearch',
+        storeName: 'data',
+      };
+    }
+    return val;
+  });
 
 const SearchIndexSchema = z.object({
   /**

--- a/packages/picosearch/src/schemas.ts
+++ b/packages/picosearch/src/schemas.ts
@@ -25,10 +25,17 @@ export type StorageDriver = z.input<typeof StorageDriverSchema>;
 
 const StorageDriverOptionsSchema = z.union([
   z.literal('localstorage'),
+  z.literal('indexeddb'),
   z.discriminatedUnion('type', [
     z.object({
       type: z.literal('localstorage'),
       key: z.string(),
+    }),
+    z.object({
+      type: z.literal('indexeddb'),
+      key: z.string(),
+      dbName: z.string().optional(),
+      storeName: z.string().optional(),
     }),
     z.object({
       type: z.literal('custom'),

--- a/packages/picosearch/src/schemas.ts
+++ b/packages/picosearch/src/schemas.ts
@@ -1,7 +1,13 @@
 import { RadixBKTreeMap } from '@picosearch/radix-bk-tree';
 import { z } from 'zod';
 import { type Document, defaultAnalyzer, defaultTokenizer } from '.';
-import { LANGUAGE_NAMES, PROCESSORS_BY_LANGUAGE } from './constants';
+import {
+  DEFAULT_INDEXEDDB_DB_NAME,
+  DEFAULT_INDEXEDDB_STORE_NAME,
+  DEFAULT_STORAGE_DRIVER_KEY,
+  LANGUAGE_NAMES,
+  PROCESSORS_BY_LANGUAGE,
+} from './constants';
 import type { RawTokenMarker, TokenInfo } from './types';
 
 // TODO: consider switching to zod/mini
@@ -30,13 +36,13 @@ const StorageDriverOptionsSchema = z
     z.discriminatedUnion('type', [
       z.object({
         type: z.literal('localstorage'),
-        key: z.string().default('picosearch'),
+        key: z.string().default(DEFAULT_STORAGE_DRIVER_KEY),
       }),
       z.object({
         type: z.literal('indexeddb'),
-        key: z.string().default('picosearch'),
-        dbName: z.string().default('picosearch'),
-        storeName: z.string().default('data'),
+        key: z.string().default(DEFAULT_STORAGE_DRIVER_KEY),
+        dbName: z.string().default(DEFAULT_INDEXEDDB_DB_NAME),
+        storeName: z.string().default(DEFAULT_INDEXEDDB_STORE_NAME),
       }),
       z.object({
         type: z.literal('custom'),
@@ -46,14 +52,14 @@ const StorageDriverOptionsSchema = z
   ])
   .transform((val) => {
     if (val === 'localstorage') {
-      return { type: 'localstorage' as const, key: 'picosearch' };
+      return { type: 'localstorage' as const, key: DEFAULT_STORAGE_DRIVER_KEY };
     }
     if (val === 'indexeddb') {
       return {
         type: 'indexeddb' as const,
-        key: 'picosearch',
-        dbName: 'picosearch',
-        storeName: 'data',
+        key: DEFAULT_STORAGE_DRIVER_KEY,
+        dbName: DEFAULT_INDEXEDDB_DB_NAME,
+        storeName: DEFAULT_INDEXEDDB_STORE_NAME,
       };
     }
     return val;

--- a/packages/picosearch/src/storage.ts
+++ b/packages/picosearch/src/storage.ts
@@ -41,8 +41,12 @@ export class IndexedDBStorageDriver implements IStorageDriver {
 
   private async openDB(): Promise<unknown> {
     return new Promise((resolve, reject) => {
-      // biome-ignore lint/suspicious/noExplicitAny: IndexedDB not available in Node.js types
-      const indexedDB = (globalThis as any).indexedDB;
+      // Check if globalThis exists and has indexedDB
+      const indexedDB =
+        typeof globalThis !== 'undefined'
+          ? // biome-ignore lint/suspicious/noExplicitAny: IndexedDB not available in Node.js types
+            (globalThis as any).indexedDB
+          : undefined;
       if (!indexedDB) {
         reject(new Error('IndexedDB is not available in this environment'));
         return;

--- a/packages/picosearch/src/storage.ts
+++ b/packages/picosearch/src/storage.ts
@@ -1,8 +1,3 @@
-import {
-  DEFAULT_INDEXEDDB_DB_NAME,
-  DEFAULT_INDEXEDDB_STORE_NAME,
-  DEFAULT_STORAGE_DRIVER_KEY,
-} from './constants';
 import type { ParsedOptions, StorageDriver } from './schemas';
 import type { Document, IStorageDriver } from './types';
 
@@ -33,10 +28,10 @@ export class IndexedDBStorageDriver implements IStorageDriver {
   private storeName: string;
   private key: string;
 
-  constructor(key: string, dbName?: string, storeName?: string) {
+  constructor(key: string, dbName: string, storeName: string) {
     this.key = key;
-    this.dbName = dbName ?? DEFAULT_INDEXEDDB_DB_NAME;
-    this.storeName = storeName ?? DEFAULT_INDEXEDDB_STORE_NAME;
+    this.dbName = dbName;
+    this.storeName = storeName;
   }
 
   private async openDB(): Promise<IDBDatabase> {
@@ -113,17 +108,6 @@ export const getStorageDriver = <T extends Document>(
   const { storageDriver } = opts;
   if (!storageDriver) {
     return undefined;
-  }
-
-  if (typeof storageDriver === 'string') {
-    switch (storageDriver) {
-      case 'localstorage':
-        return new LocalStorageDriver(DEFAULT_STORAGE_DRIVER_KEY);
-      case 'indexeddb':
-        return new IndexedDBStorageDriver(DEFAULT_STORAGE_DRIVER_KEY);
-      default:
-        throw new Error(`Unknown storage driver: ${storageDriver}`);
-    }
   }
 
   switch (storageDriver.type) {

--- a/packages/picosearch/src/storage.ts
+++ b/packages/picosearch/src/storage.ts
@@ -41,7 +41,6 @@ export class IndexedDBStorageDriver implements IStorageDriver {
 
   private async openDB(): Promise<unknown> {
     return new Promise((resolve, reject) => {
-      // Check if globalThis exists and has indexedDB
       const indexedDB =
         typeof globalThis !== 'undefined'
           ? // biome-ignore lint/suspicious/noExplicitAny: IndexedDB not available in Node.js types

--- a/packages/picosearch/src/storage.ts
+++ b/packages/picosearch/src/storage.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_STORAGE_DRIVER_KEY } from './constants';
+import {
+  DEFAULT_INDEXEDDB_DB_NAME,
+  DEFAULT_INDEXEDDB_STORE_NAME,
+  DEFAULT_STORAGE_DRIVER_KEY,
+} from './constants';
 import type { ParsedOptions, StorageDriver } from './schemas';
 import type { Document, IStorageDriver } from './types';
 
@@ -24,7 +28,89 @@ export class LocalStorageDriver implements IStorageDriver {
   }
 }
 
-// TODO: add more native storage driver like IndexedDB, FileSystem
+export class IndexedDBStorageDriver implements IStorageDriver {
+  private dbName: string;
+  private storeName: string;
+  private key: string;
+
+  constructor(key: string, dbName?: string, storeName?: string) {
+    this.key = key;
+    this.dbName = dbName ?? DEFAULT_INDEXEDDB_DB_NAME;
+    this.storeName = storeName ?? DEFAULT_INDEXEDDB_STORE_NAME;
+  }
+
+  private async openDB(): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      // biome-ignore lint/suspicious/noExplicitAny: IndexedDB not available in Node.js types
+      const indexedDB = (globalThis as any).indexedDB;
+      if (!indexedDB) {
+        throw new Error('IndexedDB is not available in this environment');
+      }
+
+      const request = indexedDB.open(this.dbName, 1);
+
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve(request.result);
+
+      // biome-ignore lint/suspicious/noExplicitAny: IndexedDB event types not available in Node.js
+      request.onupgradeneeded = (event: any) => {
+        const db = event.target.result;
+        if (!db.objectStoreNames.contains(this.storeName)) {
+          db.createObjectStore(this.storeName);
+        }
+      };
+    });
+  }
+
+  async get(): Promise<string> {
+    try {
+      const db = await this.openDB();
+      // biome-ignore lint/suspicious/noExplicitAny: IndexedDB types not available in Node.js
+      const transaction = (db as any).transaction([this.storeName], 'readonly');
+      const store = transaction.objectStore(this.storeName);
+      const request = store.get(this.key);
+
+      return new Promise((resolve, reject) => {
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+          const result = request.result;
+          resolve(result ?? '');
+        };
+      });
+    } catch (error) {
+      // Fallback to empty string if IndexedDB is not available or fails
+      return '';
+    }
+  }
+
+  async persist(value: string): Promise<void> {
+    const db = await this.openDB();
+    // biome-ignore lint/suspicious/noExplicitAny: IndexedDB types not available in Node.js
+    const transaction = (db as any).transaction([this.storeName], 'readwrite');
+    const store = transaction.objectStore(this.storeName);
+    const request = store.put(value, this.key);
+
+    return new Promise((resolve, reject) => {
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve();
+    });
+  }
+
+  async delete(): Promise<void> {
+    const db = await this.openDB();
+    // biome-ignore lint/suspicious/noExplicitAny: IndexedDB types not available in Node.js
+    const transaction = (db as any).transaction([this.storeName], 'readwrite');
+    const store = transaction.objectStore(this.storeName);
+    const request = store.delete(this.key);
+
+    return new Promise((resolve, reject) => {
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve();
+    });
+  }
+}
+
+// TODO: add more native storage driver like FileSystem
 
 export const getStorageDriver = <T extends Document>(
   opts: ParsedOptions<T>,
@@ -38,6 +124,8 @@ export const getStorageDriver = <T extends Document>(
     switch (storageDriver) {
       case 'localstorage':
         return new LocalStorageDriver(DEFAULT_STORAGE_DRIVER_KEY);
+      case 'indexeddb':
+        return new IndexedDBStorageDriver(DEFAULT_STORAGE_DRIVER_KEY);
       default:
         throw new Error(`Unknown storage driver: ${storageDriver}`);
     }
@@ -46,6 +134,12 @@ export const getStorageDriver = <T extends Document>(
   switch (storageDriver.type) {
     case 'localstorage':
       return new LocalStorageDriver(storageDriver.key);
+    case 'indexeddb':
+      return new IndexedDBStorageDriver(
+        storageDriver.key,
+        storageDriver.dbName,
+        storageDriver.storeName,
+      );
     case 'custom':
       return storageDriver.driver;
     default:

--- a/packages/picosearch/tsconfig.build.esm.json
+++ b/packages/picosearch/tsconfig.build.esm.json
@@ -4,7 +4,14 @@
     "outDir": "dist/esm",
     "module": "esnext",
     "target": "es2022",
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "lib": [
+      "es2024",
+      "ESNext.Array",
+      "ESNext.Collection",
+      "ESNext.Iterator",
+      "dom"
+    ]
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.spec.ts"]

--- a/packages/picosearch/tsconfig.build.json
+++ b/packages/picosearch/tsconfig.build.json
@@ -1,7 +1,14 @@
 {
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "lib": [
+      "es2024",
+      "ESNext.Array",
+      "ESNext.Collection",
+      "ESNext.Iterator",
+      "dom"
+    ]
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.spec.ts"]

--- a/packages/picosearch/tsconfig.json
+++ b/packages/picosearch/tsconfig.json
@@ -1,4 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*", "benchmark/*"]
+  "include": ["src/**/*", "benchmark/*"],
+  "compilerOptions": {
+    "lib": [
+      "es2024",
+      "ESNext.Array",
+      "ESNext.Collection",
+      "ESNext.Iterator",
+      "dom"
+    ]
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an IndexedDB storage driver with optional db/store config, integrates it into schemas and driver factory, and defines related defaults and DOM typings.
> 
> - **Storage**:
>   - **IndexedDB driver**: Introduces `IndexedDBStorageDriver` with `get`/`persist`/`delete` using IndexedDB; updates `getStorageDriver` to support `'indexeddb'` and `{ type: 'indexeddb', key, dbName?, storeName? }`.
>   - **Schema**: Extends `StorageDriverOptionsSchema` to include `'indexeddb'` and an `indexeddb` discriminated option with optional `dbName`/`storeName`.
>   - **Constants**: Adds `DEFAULT_INDEXEDDB_DB_NAME` and `DEFAULT_INDEXEDDB_STORE_NAME`.
>   - **Build**: Updates `tsconfig.json` to include `dom` lib (plus ESNext libs) for IndexedDB typings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11d3566eb343588b8fd9d41eb97afe002547c3ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->